### PR TITLE
feat(general-service): add general-purpose service chart

### DIFF
--- a/charts/general-service/.helmignore
+++ b/charts/general-service/.helmignore
@@ -1,0 +1,19 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+tests/

--- a/charts/general-service/Chart.yaml
+++ b/charts/general-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: general-service
+description: A general-purpose Helm chart for deploying containerized services with HTTPRoute, Service, HPA, and PDB support
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/general-service/README.md
+++ b/charts/general-service/README.md
@@ -1,0 +1,449 @@
+# general-service
+
+A general-purpose Helm chart for deploying containerized services with HTTPRoute, Service, HPA, and PDB support.
+
+## Overview
+
+This chart provides a flexible way to deploy containerized applications to Kubernetes with common production-ready features including:
+
+- Configurable Deployment with init containers
+- Service exposure (ClusterIP, LoadBalancer, NodePort)
+- HTTPRoute for Gateway API integration
+- Horizontal Pod Autoscaler (HPA)
+- Pod Disruption Budget (PDB)
+- Security hardening with sensible defaults
+
+## Installation
+
+```bash
+helm install my-release ./charts/general-service \
+  --set image.repository=nginx \
+  --set image.tag=1.21
+```
+
+## Quick Start
+
+### Basic deployment
+
+```yaml
+image:
+  repository: nginx
+  tag: "1.21"
+```
+
+### Full example with all features
+
+```yaml
+image:
+  repository: myapp
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+  pullSecrets:
+    - name: my-registry-secret
+
+replicas: 3
+containerPort: 8080
+
+command:
+  - /app/server
+args:
+  - --config=/etc/config/app.yaml
+
+env:
+  literal:
+    LOG_LEVEL: info
+    ENV: production
+  fromConfigMaps:
+    - configMapName: app-config
+      keys:
+        - key: database-url
+          envName: DATABASE_URL
+  fromSecrets:
+    - secretName: app-secrets
+      keys:
+        - key: api-key
+          envName: API_KEY
+
+volumes:
+  - name: config
+    configMap:
+      name: app-config
+  - name: tmp
+    emptyDir: {}
+
+volumeMounts:
+  - name: config
+    mountPath: /etc/config
+    readOnly: true
+  - name: tmp
+    mountPath: /tmp
+
+initContainers:
+  - name: init-db
+    image:
+      repository: postgres
+      tag: "15"
+    command:
+      - sh
+      - -c
+      - "until pg_isready -h $DB_HOST; do sleep 2; done"
+    env:
+      literal:
+        DB_HOST: postgres.default.svc
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 8080
+
+httpRoute:
+  enabled: true
+  gateway:
+    name: main-gateway
+    namespace: gateway-system
+  hostnames:
+    - myapp.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1
+```
+
+## Configuration Reference
+
+### General
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nameOverride` | Override the name of the chart | `""` |
+| `fullnameOverride` | Override the full name of the release | `""` |
+| `replicas` | Number of replicas for the deployment | `2` |
+
+### Image
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Container image repository | `""` (required) |
+| `image.tag` | Container image tag | `""` (defaults to Chart.appVersion) |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.pullSecrets` | Image pull secrets for private registries | `[]` |
+
+### Container
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `containerPort` | Container port | `8080` |
+| `command` | Override the container command | `[]` |
+| `args` | Override the container arguments | `[]` |
+| `resources` | Resource requests and limits | `{}` |
+
+### Environment Variables
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `env.literal` | Literal environment variables (key-value pairs) | `{}` |
+| `env.fromConfigMaps` | Environment variables from ConfigMaps | `[]` |
+| `env.fromSecrets` | Environment variables from Secrets | `[]` |
+
+#### Environment from ConfigMap example
+
+```yaml
+env:
+  fromConfigMaps:
+    - configMapName: my-config
+      keys:
+        - key: config-key
+          envName: MY_CONFIG_VAR  # optional, defaults to key name
+```
+
+#### Environment from Secret example
+
+```yaml
+env:
+  fromSecrets:
+    - secretName: my-secret
+      keys:
+        - key: secret-key
+          envName: MY_SECRET_VAR  # optional, defaults to key name
+```
+
+### Volumes
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `volumes` | Volumes for the pod | `[]` |
+| `volumeMounts` | Volume mounts for the container | `[]` |
+
+#### Volumes example
+
+```yaml
+volumes:
+  - name: config-volume
+    configMap:
+      name: my-config
+  - name: secret-volume
+    secret:
+      secretName: my-secret
+  - name: empty-dir
+    emptyDir: {}
+  - name: pvc-volume
+    persistentVolumeClaim:
+      claimName: my-pvc
+
+volumeMounts:
+  - name: config-volume
+    mountPath: /etc/config
+    readOnly: true
+```
+
+### Init Containers
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `initContainers` | Init containers configuration | `[]` |
+
+Init containers support the same features as the main container:
+- `name` - Container name (required)
+- `image.repository` - Image repository (required)
+- `image.tag` - Image tag (required)
+- `image.pullPolicy` - Pull policy
+- `command` - Command override
+- `args` - Arguments override
+- `env` - Environment variables (literal, fromConfigMaps, fromSecrets)
+- `volumeMounts` - Volume mounts
+- `resources` - Resource requests/limits
+- `securityContext` - Security context (inherits default if not specified)
+
+#### Init container example
+
+```yaml
+initContainers:
+  - name: init-myservice
+    image:
+      repository: busybox
+      tag: "1.36"
+      pullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - "echo initializing..."
+    env:
+      literal:
+        INIT_VAR: "init-value"
+    volumeMounts:
+      - name: shared
+        mountPath: /shared
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+```
+
+### Health Probes
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `livenessProbe` | Liveness probe configuration | `{}` |
+| `readinessProbe` | Readiness probe configuration | `{}` |
+| `startupProbe` | Startup probe configuration | `{}` |
+
+#### Probe example
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  failureThreshold: 30
+  periodSeconds: 10
+```
+
+### Service
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `service.enabled` | Enable service creation | `true` |
+| `service.type` | Service type (ClusterIP, LoadBalancer, NodePort) | `ClusterIP` |
+| `service.port` | Service port | `8080` |
+| `service.annotations` | Additional service annotations | `{}` |
+
+### HTTPRoute (Gateway API)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `httpRoute.enabled` | Enable HTTPRoute creation | `false` |
+| `httpRoute.gateway.name` | Gateway name (required when enabled) | `""` |
+| `httpRoute.gateway.namespace` | Gateway namespace | `""` (same namespace) |
+| `httpRoute.hostnames` | Hostnames for the route | `[]` |
+| `httpRoute.rules` | HTTP route rules | PathPrefix `/` |
+| `httpRoute.annotations` | Additional HTTPRoute annotations | `{}` |
+
+#### HTTPRoute example
+
+```yaml
+httpRoute:
+  enabled: true
+  gateway:
+    name: main-gateway
+    namespace: gateway-system
+  hostnames:
+    - myapp.example.com
+    - www.myapp.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+### Horizontal Pod Autoscaler (HPA)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `hpa.enabled` | Enable HPA creation | `false` |
+| `hpa.minReplicas` | Minimum number of replicas | `2` |
+| `hpa.maxReplicas` | Maximum number of replicas | `10` |
+| `hpa.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80` |
+| `hpa.targetMemoryUtilizationPercentage` | Target memory utilization percentage | `null` |
+
+When HPA is enabled, the `replicas` field is not set in the Deployment to allow HPA to manage scaling.
+
+### Pod Disruption Budget (PDB)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `pdb.enabled` | Enable PDB creation | `false` |
+| `pdb.minAvailable` | Minimum available pods (number or percentage) | `1` |
+| `pdb.maxUnavailable` | Maximum unavailable pods (alternative to minAvailable) | `null` |
+
+### Security Context
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podSecurityContext` | Pod-level security context | `runAsNonRoot: true` |
+| `securityContext` | Container-level security context | See below |
+
+Default container security context (applied to main and init containers):
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+### Pod Scheduling
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodeSelector` | Node selector for pod scheduling | `{}` |
+| `tolerations` | Tolerations for pod scheduling | `[]` |
+| `affinity` | Affinity rules for pod scheduling | `{}` |
+
+### Pod Metadata
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podAnnotations` | Additional pod annotations | `{}` |
+| `podLabels` | Additional pod labels | `{}` |
+
+### Service Account
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create a service account | `false` |
+| `serviceAccount.name` | Service account name | `""` (generated) |
+| `serviceAccount.annotations` | Service account annotations | `{}` |
+
+#### Service account example (AWS IRSA)
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/my-role
+```
+
+## Security Defaults
+
+This chart ships with security-hardened defaults:
+
+1. **Pod runs as non-root**: `runAsNonRoot: true`
+2. **No privilege escalation**: `allowPrivilegeEscalation: false`
+3. **Read-only root filesystem**: `readOnlyRootFilesystem: true`
+4. **All capabilities dropped**: `capabilities.drop: [ALL]`
+
+If your application requires different security settings, you can override these values:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+
+securityContext:
+  allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop: []
+    add:
+      - NET_BIND_SERVICE
+```
+
+## Upgrading
+
+### To 0.x
+
+Initial release - no upgrade notes.

--- a/charts/general-service/templates/_helpers.tpl
+++ b/charts/general-service/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "general-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "general-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "general-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "general-service.labels" -}}
+helm.sh/chart: {{ include "general-service.chart" . }}
+{{ include "general-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "general-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "general-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "general-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "general-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "general-service.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}

--- a/charts/general-service/templates/deployment.yaml
+++ b/charts/general-service/templates/deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "general-service.fullname" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.hpa.enabled }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "general-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "general-service.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "general-service.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- range .Values.initContainers }}
+        - name: {{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: {{ .image.pullPolicy | default "IfNotPresent" }}
+          {{- with .command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .env.literal .env.fromConfigMaps .env.fromSecrets }}
+          env:
+            {{- range $key, $value := .env.literal }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range .env.fromConfigMaps }}
+            {{- $configMapName := .configMapName }}
+            {{- range .keys }}
+            - name: {{ .envName | default .key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $configMapName }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- end }}
+            {{- range .env.fromSecrets }}
+            {{- $secretName := .secretName }}
+            {{- range .keys }}
+            - name: {{ .envName | default .key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- else }}
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "general-service.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if or .Values.env.literal .Values.env.fromConfigMaps .Values.env.fromSecrets }}
+          env:
+            {{- range $key, $value := .Values.env.literal }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range .Values.env.fromConfigMaps }}
+            {{- $configMapName := .configMapName }}
+            {{- range .keys }}
+            - name: {{ .envName | default .key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $configMapName }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- end }}
+            {{- range .Values.env.fromSecrets }}
+            {{- $secretName := .secretName }}
+            {{- range .keys }}
+            - name: {{ .envName | default .key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/general-service/templates/deployment.yaml
+++ b/charts/general-service/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .env.literal .env.fromConfigMaps .env.fromSecrets }}
+          {{- if and .env (or .env.literal .env.fromConfigMaps .env.fromSecrets) }}
           env:
             {{- range $key, $value := .env.literal }}
             - name: {{ $key }}

--- a/charts/general-service/templates/hpa.yaml
+++ b/charts/general-service/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "general-service.fullname" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "general-service.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/general-service/templates/httproute.yaml
+++ b/charts/general-service/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "general-service.fullname" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gateway.name }}
+      {{- if .Values.httpRoute.gateway.namespace }}
+      namespace: {{ .Values.httpRoute.gateway.namespace }}
+      {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - {{- if .matches }}
+      matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "general-service.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/general-service/templates/pdb.yaml
+++ b/charts/general-service/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "general-service.fullname" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "general-service.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/general-service/templates/service.yaml
+++ b/charts/general-service/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "general-service.fullname" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "general-service.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/general-service/templates/serviceaccount.yaml
+++ b/charts/general-service/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "general-service.serviceAccountName" . }}
+  labels:
+    {{- include "general-service.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/general-service/tests/deployment_test.yaml
+++ b/charts/general-service/tests/deployment_test.yaml
@@ -1,0 +1,330 @@
+suite: deployment tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should render deployment with default values
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:1.21"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: should render default security context dropping all privileges
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should not set replicas when HPA is enabled
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      hpa:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
+
+  - it: should render literal environment variables
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      env:
+        literal:
+          MY_VAR: "my-value"
+          ANOTHER_VAR: "another-value"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: "my-value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ANOTHER_VAR
+            value: "another-value"
+
+  - it: should render environment variables from ConfigMap
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      env:
+        fromConfigMaps:
+          - configMapName: my-config
+            keys:
+              - key: config-key
+                envName: MY_CONFIG_VAR
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_CONFIG_VAR
+            valueFrom:
+              configMapKeyRef:
+                name: my-config
+                key: config-key
+
+  - it: should render environment variables from Secret
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      env:
+        fromSecrets:
+          - secretName: my-secret
+            keys:
+              - key: secret-key
+                envName: MY_SECRET_VAR
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: secret-key
+
+  - it: should render command and args
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      command:
+        - /bin/sh
+        - -c
+      args:
+        - "echo hello"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -c
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "echo hello"
+
+  - it: should render volumes and volumeMounts
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: my-config
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-volume
+            configMap:
+              name: my-config
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config-volume
+            mountPath: /etc/config
+            readOnly: true
+
+  - it: should render init containers with full features
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      initContainers:
+        - name: init-myservice
+          image:
+            repository: busybox
+            tag: "1.36"
+            pullPolicy: Always
+          command:
+            - sh
+            - -c
+          args:
+            - "echo initializing"
+          env:
+            literal:
+              INIT_VAR: "init-value"
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      volumes:
+        - name: shared
+          emptyDir: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-myservice
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "busybox:1.36"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - sh
+            - -c
+      - equal:
+          path: spec.template.spec.initContainers[0].args
+          value:
+            - "echo initializing"
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: INIT_VAR
+            value: "init-value"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: shared
+            mountPath: /shared
+
+  - it: should apply default security context to init containers
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      initContainers:
+        - name: init-myservice
+          image:
+            repository: busybox
+            tag: "1.36"
+          command:
+            - echo
+            - hello
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should allow init container to override security context
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      initContainers:
+        - name: init-myservice
+          image:
+            repository: busybox
+            tag: "1.36"
+          command:
+            - echo
+            - hello
+          securityContext:
+            readOnlyRootFilesystem: false
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem
+          value: false
+
+  - it: should render liveness and readiness probes
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8080
+        initialDelaySeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 8080
+        initialDelaySeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+
+  - it: should render resource requests and limits
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+
+  - it: should render image pull secrets
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+        pullSecrets:
+          - name: my-registry-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-registry-secret
+
+  - it: should use chart appVersion as default image tag
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:1.0.0"

--- a/charts/general-service/tests/hpa_test.yaml
+++ b/charts/general-service/tests/hpa_test.yaml
@@ -1,0 +1,87 @@
+suite: hpa tests
+templates:
+  - hpa.yaml
+tests:
+  - it: should not render hpa when disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render hpa when enabled with defaults
+    set:
+      image:
+        repository: nginx
+      hpa:
+        enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80
+
+  - it: should render hpa with custom values
+    set:
+      image:
+        repository: nginx
+      hpa:
+        enabled: true
+        minReplicas: 3
+        maxReplicas: 20
+        targetCPUUtilizationPercentage: 70
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 3
+      - equal:
+          path: spec.maxReplicas
+          value: 20
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 70
+
+  - it: should render hpa with memory metric
+    set:
+      image:
+        repository: nginx
+      hpa:
+        enabled: true
+        targetMemoryUtilizationPercentage: 75
+    asserts:
+      - equal:
+          path: spec.metrics[1].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 75
+
+  - it: should reference the correct deployment
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      hpa:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: my-release-general-service

--- a/charts/general-service/tests/httproute_test.yaml
+++ b/charts/general-service/tests/httproute_test.yaml
@@ -1,0 +1,93 @@
+suite: httproute tests
+templates:
+  - httproute.yaml
+tests:
+  - it: should not render httproute when disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render httproute when enabled
+    set:
+      image:
+        repository: nginx
+      httpRoute:
+        enabled: true
+        gateway:
+          name: my-gateway
+          namespace: gateway-ns
+        hostnames:
+          - myapp.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-ns
+      - contains:
+          path: spec.hostnames
+          content: myapp.example.com
+
+  - it: should render httproute with default rules
+    set:
+      image:
+        repository: nginx
+      httpRoute:
+        enabled: true
+        gateway:
+          name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should use service port in backendRefs
+    set:
+      image:
+        repository: nginx
+      service:
+        port: 3000
+      httpRoute:
+        enabled: true
+        gateway:
+          name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3000
+
+  - it: should render httproute annotations
+    set:
+      image:
+        repository: nginx
+      httpRoute:
+        enabled: true
+        gateway:
+          name: my-gateway
+        annotations:
+          custom-annotation: custom-value
+    asserts:
+      - equal:
+          path: metadata.annotations["custom-annotation"]
+          value: custom-value
+
+  - it: should render httproute without gateway namespace if not specified
+    set:
+      image:
+        repository: nginx
+      httpRoute:
+        enabled: true
+        gateway:
+          name: my-gateway
+    asserts:
+      - isNull:
+          path: spec.parentRefs[0].namespace

--- a/charts/general-service/tests/pdb_test.yaml
+++ b/charts/general-service/tests/pdb_test.yaml
@@ -1,0 +1,71 @@
+suite: pdb tests
+templates:
+  - pdb.yaml
+tests:
+  - it: should not render pdb when disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render pdb when enabled with minAvailable
+    set:
+      image:
+        repository: nginx
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render pdb with maxUnavailable
+    set:
+      image:
+        repository: nginx
+      pdb:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should render pdb with percentage minAvailable
+    set:
+      image:
+        repository: nginx
+      pdb:
+        enabled: true
+        minAvailable: "50%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+
+  - it: should use correct selector labels
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      pdb:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: general-service
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: my-release

--- a/charts/general-service/tests/service_test.yaml
+++ b/charts/general-service/tests/service_test.yaml
@@ -1,0 +1,57 @@
+suite: service tests
+templates:
+  - service.yaml
+tests:
+  - it: should render service with default values
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+
+  - it: should not render service when disabled
+    set:
+      image:
+        repository: nginx
+      service:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render service with LoadBalancer type
+    set:
+      image:
+        repository: nginx
+      service:
+        type: LoadBalancer
+        port: 80
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+
+  - it: should render service annotations
+    set:
+      image:
+        repository: nginx
+      service:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb

--- a/charts/general-service/tests/serviceaccount_test.yaml
+++ b/charts/general-service/tests/serviceaccount_test.yaml
@@ -1,0 +1,51 @@
+suite: serviceaccount tests
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should not render serviceaccount when disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render serviceaccount when enabled
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: my-release-general-service
+
+  - it: should render serviceaccount with custom name
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should render serviceaccount annotations
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/my-role
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789:role/my-role

--- a/charts/general-service/values.schema.json
+++ b/charts/general-service/values.schema.json
@@ -24,7 +24,6 @@
       "properties": {
         "repository": {
           "type": "string",
-          "minLength": 1,
           "description": "Container image repository"
         },
         "tag": {

--- a/charts/general-service/values.schema.json
+++ b/charts/general-service/values.schema.json
@@ -1,0 +1,445 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the release"
+    },
+    "replicas": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 2,
+      "description": "Number of replicas for the deployment"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "IfNotPresent",
+          "description": "Image pull policy"
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "description": "Image pull secrets for private registries"
+        }
+      }
+    },
+    "containerPort": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "default": 8080,
+      "description": "Container port configuration"
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override the container command"
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override the container arguments"
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "description": "Resource requests and limits"
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "literal": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Literal environment variables"
+        },
+        "fromConfigMaps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["configMapName", "keys"],
+            "properties": {
+              "configMapName": {
+                "type": "string"
+              },
+              "keys": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["key"],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "envName": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "Environment variables from ConfigMaps"
+        },
+        "fromSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["secretName", "keys"],
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "keys": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["key"],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "envName": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "Environment variables from Secrets"
+        }
+      },
+      "description": "Environment variables configuration"
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Volume mounts for the container"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Volumes for the pod"
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "image"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "image": {
+            "type": "object",
+            "required": ["repository", "tag"],
+            "properties": {
+              "repository": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "enum": ["Always", "IfNotPresent", "Never"]
+              }
+            }
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "env": {
+            "type": "object",
+            "properties": {
+              "literal": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "fromConfigMaps": {
+                "type": "array"
+              },
+              "fromSecrets": {
+                "type": "array"
+              }
+            }
+          },
+          "volumeMounts": {
+            "type": "array"
+          },
+          "resources": {
+            "type": "object"
+          },
+          "securityContext": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "description": "Init containers configuration"
+    },
+    "livenessProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Liveness probe configuration"
+    },
+    "readinessProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Readiness probe configuration"
+    },
+    "startupProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Startup probe configuration"
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "LoadBalancer", "NodePort"],
+          "default": "ClusterIP"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8080
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Service configuration"
+    },
+    "httpRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "HTTPRoute configuration"
+    },
+    "hpa": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 2
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 10
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "description": "Horizontal Pod Autoscaler configuration"
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minAvailable": {
+          "type": ["integer", "string", "null"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string", "null"]
+        }
+      },
+      "description": "Pod Disruption Budget configuration"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Pod-level security context"
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Container-level security context"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Node selector for pod scheduling"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Tolerations for pod scheduling"
+    },
+    "affinity": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Affinity rules for pod scheduling"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Additional pod annotations"
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Additional pod labels"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Service account configuration"
+    }
+  },
+  "required": ["image"]
+}

--- a/charts/general-service/values.yaml
+++ b/charts/general-service/values.yaml
@@ -1,0 +1,214 @@
+# General Service Chart - Default Values
+
+# -- Number of replicas for the deployment
+replicas: 2
+
+# -- Image configuration
+image:
+  # -- Container image repository
+  repository: ""
+  # -- Container image tag (defaults to Chart.appVersion if not set)
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image pull secrets for private registries
+  pullSecrets: []
+  #   - name: my-registry-secret
+
+# -- Container port configuration
+containerPort: 8080
+
+# -- Override the container command
+command: []
+#   - /bin/sh
+#   - -c
+
+# -- Override the container arguments
+args: []
+#   - "echo hello && sleep 3600"
+
+# -- Resource requests and limits
+resources: {}
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
+#   limits:
+#     cpu: 500m
+#     memory: 512Mi
+
+# -- Environment variables
+env:
+  # -- Literal environment variables (key-value pairs)
+  literal: {}
+  #   MY_VAR: "my-value"
+  #   ANOTHER_VAR: "another-value"
+
+  # -- Environment variables from ConfigMaps
+  fromConfigMaps: []
+  #   - configMapName: my-config
+  #     keys:
+  #       - key: config-key
+  #         envName: MY_CONFIG_VAR  # optional, defaults to key name
+
+  # -- Environment variables from Secrets
+  fromSecrets: []
+  #   - secretName: my-secret
+  #     keys:
+  #       - key: secret-key
+  #         envName: MY_SECRET_VAR  # optional, defaults to key name
+
+# -- Volume mounts for the container
+volumeMounts: []
+#   - name: config-volume
+#     mountPath: /etc/config
+#     readOnly: true
+
+# -- Volumes for the pod
+volumes: []
+#   - name: config-volume
+#     configMap:
+#       name: my-config
+#   - name: secret-volume
+#     secret:
+#       secretName: my-secret
+#   - name: empty-dir
+#     emptyDir: {}
+#   - name: pvc-volume
+#     persistentVolumeClaim:
+#       claimName: my-pvc
+
+# -- Init containers configuration
+initContainers: []
+#   - name: init-myservice
+#     image:
+#       repository: busybox
+#       tag: "1.36"
+#       pullPolicy: IfNotPresent
+#     command:
+#       - sh
+#       - -c
+#       - "echo initializing..."
+#     args: []
+#     env:
+#       literal:
+#         INIT_VAR: "init-value"
+#       fromConfigMaps: []
+#       fromSecrets: []
+#     volumeMounts: []
+#     resources: {}
+#     securityContext: {}  # Inherits default if not specified
+
+# -- Liveness probe configuration
+livenessProbe: {}
+#   httpGet:
+#     path: /healthz
+#     port: 8080
+#   initialDelaySeconds: 10
+#   periodSeconds: 10
+
+# -- Readiness probe configuration
+readinessProbe: {}
+#   httpGet:
+#     path: /ready
+#     port: 8080
+#   initialDelaySeconds: 5
+#   periodSeconds: 5
+
+# -- Startup probe configuration
+startupProbe: {}
+#   httpGet:
+#     path: /healthz
+#     port: 8080
+#   failureThreshold: 30
+#   periodSeconds: 10
+
+# -- Service configuration
+service:
+  # -- Enable service creation
+  enabled: true
+  # -- Service type (ClusterIP, LoadBalancer, NodePort)
+  type: ClusterIP
+  # -- Service port
+  port: 8080
+  # -- Additional service annotations
+  annotations: {}
+
+# -- HTTPRoute configuration (Gateway API)
+httpRoute:
+  # -- Enable HTTPRoute creation
+  enabled: false
+  # -- Gateway reference (required when enabled)
+  gateway:
+    # -- Gateway name
+    name: ""
+    # -- Gateway namespace (defaults to same namespace as HTTPRoute)
+    namespace: ""
+  # -- Hostnames for the route
+  hostnames: []
+  #   - myapp.example.com
+  # -- HTTP route rules
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+
+# -- Horizontal Pod Autoscaler configuration
+hpa:
+  # -- Enable HPA creation
+  enabled: false
+  # -- Minimum number of replicas
+  minReplicas: 2
+  # -- Maximum number of replicas
+  maxReplicas: 10
+  # -- Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage (optional)
+  targetMemoryUtilizationPercentage: null
+
+# -- Pod Disruption Budget configuration
+pdb:
+  # -- Enable PDB creation
+  enabled: false
+  # -- Minimum available pods (can be number or percentage)
+  minAvailable: 1
+  # -- Maximum unavailable pods (alternative to minAvailable)
+  maxUnavailable: null
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+
+# -- Container-level security context (applied to main container and init containers by default)
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Additional pod annotations
+podAnnotations: {}
+
+# -- Additional pod labels
+podLabels: {}
+
+# -- Service account configuration
+serviceAccount:
+  # -- Create a service account
+  create: false
+  # -- Service account name (generated if not set and create is true)
+  name: ""
+  # -- Service account annotations
+  annotations: {}


### PR DESCRIPTION
A comprehensive Helm chart for deploying containerized services with:

- Deployment with configurable replicas (default: 2)
- Container image configuration (repository, tag, pullPolicy, pullSecrets)
- Command and args override support
- Environment variables from literals, ConfigMaps, and Secrets
- Arbitrary volumes and volume mounts
- Init containers with full feature parity
- Default security context (drop ALL capabilities, non-root, read-only fs)
- Service with configurable type and port (default: 8080)
- HTTPRoute (Gateway API) with gateway reference
- HorizontalPodAutoscaler with CPU/memory targets
- PodDisruptionBudget with minAvailable/maxUnavailable
- ServiceAccount creation
- Health probes (liveness, readiness, startup)
- Pod scheduling (nodeSelector, tolerations, affinity)

Includes comprehensive unit tests and JSON schema validation.

https://claude.ai/code/session_01McbcS2vsaEgMc8fSBVzGtV