### PR TITLE
feat(claw): add claw bot Helm chart

### DIFF
--- a/charts/claw/.helmignore
+++ b/charts/claw/.helmignore
@@ -1,0 +1,19 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+tests/

--- a/charts/claw/Chart.yaml
+++ b/charts/claw/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: claw
+description: A Helm chart for deploying claw bots with hardened security, PVC, and configurable RBAC
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/claw/templates/_helpers.tpl
+++ b/charts/claw/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "claw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "claw.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "claw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "claw.labels" -}}
+helm.sh/chart: {{ include "claw.chart" . }}
+{{ include "claw.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "claw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "claw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "claw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "claw.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "claw.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Return the PVC name
+*/}}
+{{- define "claw.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "claw.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/claw/templates/clusterrole.yaml
+++ b/charts/claw/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterRole.rules }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{- toYaml .Values.rbac.clusterRole.rules | nindent 2 }}
+{{- end }}

--- a/charts/claw/templates/clusterrolebinding.yaml
+++ b/charts/claw/templates/clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterRole.rules }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "claw.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "claw.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/claw/templates/deployment.yaml
+++ b/charts/claw/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.deployment.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- with .Values.deployment.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "claw.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.deployment.podAnnotations .Values.commonAnnotations }}
+      annotations:
+        {{- with .Values.deployment.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "claw.selectorLabels" . | nindent 8 }}
+        {{- with .Values.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "claw.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "claw.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: workspace
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "claw.pvcName" . }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/claw/templates/pvc.yaml
+++ b/charts/claw/templates/pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/claw/templates/role.yaml
+++ b/charts/claw/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.role.rules }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{- toYaml .Values.rbac.role.rules | nindent 2 }}
+{{- end }}

--- a/charts/claw/templates/rolebinding.yaml
+++ b/charts/claw/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.rbac.create .Values.rbac.role.rules }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "claw.fullname" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "claw.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "claw.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/claw/templates/serviceaccount.yaml
+++ b/charts/claw/templates/serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "claw.serviceAccountName" . }}
+  labels:
+    {{- include "claw.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/claw/templates/serviceaccount.yaml
+++ b/charts/claw/templates/serviceaccount.yaml
@@ -11,12 +11,13 @@ metadata:
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/claw/tests/deployment_test.yaml
+++ b/charts/claw/tests/deployment_test.yaml
@@ -1,0 +1,345 @@
+suite: deployment tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should render deployment with default values
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:1.21"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should render default security context with all capabilities dropped
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should render workspace PVC volume and volumeMount
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: workspace
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: my-release-claw
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: workspace
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /workspace
+
+  - it: should use custom mountPath
+    set:
+      image:
+        repository: nginx
+      persistence:
+        mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /data
+
+  - it: should reference existingClaim when set
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      persistence:
+        existingClaim: my-existing-pvc
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: my-existing-pvc
+
+  - it: should render command and args
+    set:
+      image:
+        repository: nginx
+        tag: "1.21"
+      command:
+        - /bin/sh
+        - -c
+      args:
+        - "echo hello"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -c
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "echo hello"
+
+  - it: should render environment variables
+    set:
+      image:
+        repository: nginx
+      env:
+        - name: MY_VAR
+          value: "my-value"
+        - name: SECRET_VAR
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: secret-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: "my-value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: secret-key
+
+  - it: should render additional volumes and volumeMounts
+    set:
+      image:
+        repository: nginx
+      volumes:
+        - name: config-volume
+          configMap:
+            name: my-config
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: workspace
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-volume
+            configMap:
+              name: my-config
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config-volume
+            mountPath: /etc/config
+            readOnly: true
+
+  - it: should render resource requests and limits
+    set:
+      image:
+        repository: nginx
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+
+  - it: should render image pull secrets
+    set:
+      image:
+        repository: nginx
+      imagePullSecrets:
+        - name: my-registry-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-registry-secret
+
+  - it: should use chart appVersion as default image tag
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:1.0.0"
+
+  - it: should render deployment annotations
+    set:
+      image:
+        repository: nginx
+      deployment:
+        annotations:
+          deploy-source: helm
+    asserts:
+      - equal:
+          path: metadata.annotations["deploy-source"]
+          value: helm
+
+  - it: should render deployment labels
+    set:
+      image:
+        repository: nginx
+      deployment:
+        labels:
+          custom-deploy-label: custom-deploy-value
+    asserts:
+      - equal:
+          path: metadata.labels["custom-deploy-label"]
+          value: custom-deploy-value
+
+  - it: should render pod labels and annotations
+    set:
+      image:
+        repository: nginx
+      deployment:
+        podLabels:
+          pod-custom-label: pod-value
+        podAnnotations:
+          pod-custom-annotation: pod-anno-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["pod-custom-label"]
+          value: pod-value
+      - equal:
+          path: spec.template.metadata.annotations["pod-custom-annotation"]
+          value: pod-anno-value
+
+  - it: should include common labels on pod template
+    set:
+      image:
+        repository: nginx
+      commonLabels:
+        team: claw-bots
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["team"]
+          value: claw-bots
+
+  - it: should merge deployment and common annotations on deployment metadata
+    set:
+      image:
+        repository: nginx
+      deployment:
+        annotations:
+          deploy-key: deploy-value
+      commonAnnotations:
+        common-key: common-value
+    asserts:
+      - equal:
+          path: metadata.annotations["deploy-key"]
+          value: deploy-value
+      - equal:
+          path: metadata.annotations["common-key"]
+          value: common-value
+
+  - it: should merge pod and common annotations on pod template
+    set:
+      image:
+        repository: nginx
+      deployment:
+        podAnnotations:
+          pod-key: pod-value
+      commonAnnotations:
+        common-key: common-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["pod-key"]
+          value: pod-value
+      - equal:
+          path: spec.template.metadata.annotations["common-key"]
+          value: common-value
+
+  - it: should not set serviceAccountName when create is false
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when create is true
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-release-claw
+
+  - it: should render nodeSelector, tolerations, and affinity
+    set:
+      image:
+        repository: nginx
+      nodeSelector:
+        disktype: ssd
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: claw
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - arm64
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: claw
+            effect: NoSchedule
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch

--- a/charts/claw/tests/pvc_test.yaml
+++ b/charts/claw/tests/pvc_test.yaml
@@ -80,3 +80,21 @@ tests:
     asserts:
       - isNull:
           path: spec.storageClassName
+
+  - it: should include common labels and annotations
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+      commonLabels:
+        team: claw-bots
+      commonAnnotations:
+        managed-by: platform-team
+    asserts:
+      - equal:
+          path: metadata.labels["team"]
+          value: claw-bots
+      - equal:
+          path: metadata.annotations["managed-by"]
+          value: platform-team

--- a/charts/claw/tests/pvc_test.yaml
+++ b/charts/claw/tests/pvc_test.yaml
@@ -1,0 +1,82 @@
+suite: pvc tests
+templates:
+  - pvc.yaml
+tests:
+  - it: should not render pvc when persistence is disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render pvc when persistence is enabled
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: my-release-claw
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteOnce
+
+  - it: should not render pvc when existingClaim is set
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+        existingClaim: my-existing-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render pvc with custom size and access modes
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+        size: 50Gi
+        accessModes:
+          - ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany
+
+  - it: should render pvc with storageClassName when set
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+        storageClassName: gp3
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: gp3
+
+  - it: should not have storageClassName when empty
+    set:
+      image:
+        repository: nginx
+      persistence:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.storageClassName

--- a/charts/claw/tests/rbac_all_test.yaml
+++ b/charts/claw/tests/rbac_all_test.yaml
@@ -1,0 +1,30 @@
+suite: rbac all four resources tests
+templates:
+  - role.yaml
+  - rolebinding.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+tests:
+  - it: should render all four RBAC resources when both have rules
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+      rbac:
+        create: true
+        role:
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get"]
+        clusterRole:
+          rules:
+            - apiGroups: [""]
+              resources: ["nodes"]
+              verbs: ["get"]
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/claw/tests/rbac_clusterrole_test.yaml
+++ b/charts/claw/tests/rbac_clusterrole_test.yaml
@@ -1,0 +1,23 @@
+suite: clusterrole tests
+templates:
+  - clusterrole.yaml
+tests:
+  - it: should render clusterrole when clusterRole has rules
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      rbac:
+        create: true
+        clusterRole:
+          rules:
+            - apiGroups: [""]
+              resources: ["nodes"]
+              verbs: ["get", "list"]
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules[0].resources[0]
+          value: nodes

--- a/charts/claw/tests/rbac_clusterrolebinding_test.yaml
+++ b/charts/claw/tests/rbac_clusterrolebinding_test.yaml
@@ -1,0 +1,28 @@
+suite: clusterrolebinding tests
+templates:
+  - clusterrolebinding.yaml
+tests:
+  - it: should render clusterrolebinding when clusterRole has rules
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+      rbac:
+        create: true
+        clusterRole:
+          rules:
+            - apiGroups: [""]
+              resources: ["nodes"]
+              verbs: ["get"]
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount

--- a/charts/claw/tests/rbac_role_test.yaml
+++ b/charts/claw/tests/rbac_role_test.yaml
@@ -1,0 +1,32 @@
+suite: role tests
+templates:
+  - role.yaml
+tests:
+  - it: should render role when rbac.create is true with role rules
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      rbac:
+        create: true
+        role:
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch"]
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: my-release-claw
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: ""
+      - equal:
+          path: rules[0].resources[0]
+          value: pods
+      - equal:
+          path: rules[0].verbs[0]
+          value: get

--- a/charts/claw/tests/rbac_role_test.yaml
+++ b/charts/claw/tests/rbac_role_test.yaml
@@ -15,6 +15,10 @@ tests:
             - apiGroups: [""]
               resources: ["pods"]
               verbs: ["get", "list", "watch"]
+      commonLabels:
+        team: claw-bots
+      commonAnnotations:
+        managed-by: platform-team
     asserts:
       - isKind:
           of: Role
@@ -30,3 +34,9 @@ tests:
       - equal:
           path: rules[0].verbs[0]
           value: get
+      - equal:
+          path: metadata.labels["team"]
+          value: claw-bots
+      - equal:
+          path: metadata.annotations["managed-by"]
+          value: platform-team

--- a/charts/claw/tests/rbac_rolebinding_test.yaml
+++ b/charts/claw/tests/rbac_rolebinding_test.yaml
@@ -1,0 +1,28 @@
+suite: rolebinding tests
+templates:
+  - rolebinding.yaml
+tests:
+  - it: should render rolebinding when rbac.create is true with role rules
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+      rbac:
+        create: true
+        role:
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get"]
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount

--- a/charts/claw/tests/rbac_test.yaml
+++ b/charts/claw/tests/rbac_test.yaml
@@ -1,0 +1,24 @@
+suite: rbac disabled tests
+templates:
+  - role.yaml
+  - rolebinding.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+tests:
+  - it: should not render role when rbac is disabled
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render role when rbac.create is true but role.rules is empty
+    set:
+      image:
+        repository: nginx
+      rbac:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/claw/tests/serviceaccount_test.yaml
+++ b/charts/claw/tests/serviceaccount_test.yaml
@@ -80,3 +80,21 @@ tests:
       - equal:
           path: metadata.annotations["managed-by"]
           value: platform-team
+
+  - it: should merge serviceAccount and common annotations without overwriting
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        annotations:
+          sa-specific-key: sa-specific-value
+      commonAnnotations:
+        common-key: common-value
+    asserts:
+      - equal:
+          path: metadata.annotations["sa-specific-key"]
+          value: sa-specific-value
+      - equal:
+          path: metadata.annotations["common-key"]
+          value: common-value

--- a/charts/claw/tests/serviceaccount_test.yaml
+++ b/charts/claw/tests/serviceaccount_test.yaml
@@ -1,0 +1,82 @@
+suite: serviceaccount tests
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should not render serviceaccount when create is false
+    set:
+      image:
+        repository: nginx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render serviceaccount when create is true
+    release:
+      name: my-release
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: my-release-claw
+
+  - it: should render serviceaccount with custom name
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should render serviceaccount annotations
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/my-role
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789:role/my-role
+
+  - it: should render serviceaccount with custom labels
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+        labels:
+          custom-label: custom-value
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+
+  - it: should include common labels and annotations
+    set:
+      image:
+        repository: nginx
+      serviceAccount:
+        create: true
+      commonLabels:
+        team: claw-bots
+      commonAnnotations:
+        managed-by: platform-team
+    asserts:
+      - equal:
+          path: metadata.labels["team"]
+          value: claw-bots
+      - equal:
+          path: metadata.annotations["managed-by"]
+          value: platform-team

--- a/charts/claw/values.schema.json
+++ b/charts/claw/values.schema.json
@@ -16,6 +16,7 @@
       "properties": {
         "repository": {
           "type": "string",
+          "minLength": 1,
           "description": "Container image repository"
         },
         "tag": {

--- a/charts/claw/values.schema.json
+++ b/charts/claw/values.schema.json
@@ -1,0 +1,287 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of replicas for the deployment"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "IfNotPresent",
+          "description": "Image pull policy"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      },
+      "description": "Image pull secrets for private registries"
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override the container command"
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override the container arguments"
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Resource requests and limits"
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Volume mounts for the container"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Volumes for the pod"
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Environment variables"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Pod-level security context"
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Container-level security context"
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable PVC creation"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC"
+        },
+        "size": {
+          "type": "string",
+          "default": "10Gi",
+          "description": "PVC size"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+          },
+          "description": "PVC access modes"
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "PVC storage class name"
+        },
+        "mountPath": {
+          "type": "string",
+          "default": "/workspace",
+          "description": "Mount path for the PVC"
+        }
+      },
+      "description": "Persistence configuration"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create a service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "Service account name"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Service account annotations"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Service account labels"
+        }
+      },
+      "description": "Service account configuration"
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create RBAC resources"
+        },
+        "role": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "Role rules"
+            }
+          },
+          "description": "Namespaced role configuration"
+        },
+        "clusterRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": "ClusterRole rules"
+            }
+          },
+          "description": "ClusterRole configuration"
+        }
+      },
+      "description": "RBAC configuration"
+    },
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Deployment labels"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Deployment annotations"
+        },
+        "podLabels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Pod labels"
+        },
+        "podAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Pod annotations"
+        }
+      },
+      "description": "Deployment configuration"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Node selector for pod scheduling"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "description": "Tolerations for pod scheduling"
+    },
+    "affinity": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Affinity rules for pod scheduling"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the release"
+    },
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Common labels added to all resources"
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Common annotations added to all resources"
+    }
+  },
+  "required": ["image"]
+}

--- a/charts/claw/values.schema.json
+++ b/charts/claw/values.schema.json
@@ -16,7 +16,6 @@
       "properties": {
         "repository": {
           "type": "string",
-          "minLength": 1,
           "description": "Container image repository"
         },
         "tag": {

--- a/charts/claw/values.yaml
+++ b/charts/claw/values.yaml
@@ -1,0 +1,146 @@
+# Claw Chart - Default Values
+
+# -- Number of replicas for the deployment
+replicaCount: 1
+
+# -- Image configuration
+image:
+  # -- Container image repository
+  repository: ""
+  # -- Container image tag (defaults to Chart.appVersion if not set)
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+#   - name: my-registry-secret
+
+# -- Override the container command
+command: []
+#   - /bin/sh
+#   - -c
+
+# -- Override the container arguments
+args: []
+
+# -- Resource requests and limits
+resources: {}
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
+#   limits:
+#     cpu: 500m
+#     memory: 512Mi
+
+# -- Volume mounts for the container
+volumeMounts: []
+#   - name: extra-volume
+#     mountPath: /extra
+#     readOnly: true
+
+# -- Volumes for the pod
+volumes: []
+#   - name: extra-volume
+#     configMap:
+#       name: my-config
+
+# -- Environment variables
+env: []
+#   - name: MY_VAR
+#     value: "my-value"
+#   - name: SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: secret-key
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+
+# -- Container-level security context
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Persistence configuration
+persistence:
+  # -- Enable PVC creation
+  enabled: false
+  # -- Use an existing PVC (mutually exclusive with enabled)
+  existingClaim: ""
+  # -- PVC size
+  size: 10Gi
+  # -- PVC access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- PVC storage class name
+  storageClassName: ""
+  # -- Mount path for the PVC
+  mountPath: /workspace
+
+# -- Service account configuration
+serviceAccount:
+  # -- Create a service account
+  create: false
+  # -- Service account name (generated if not set and create is true)
+  name: ""
+  # -- Service account annotations
+  annotations: {}
+  # -- Service account labels
+  labels: {}
+
+# -- RBAC configuration
+rbac:
+  # -- Create RBAC resources
+  create: false
+  # -- Namespaced role configuration
+  role:
+    # -- Role rules
+    rules: []
+    #   - apiGroups: [""]
+    #     resources: ["pods"]
+    #     verbs: ["get", "list", "watch"]
+  # -- ClusterRole configuration
+  clusterRole:
+    # -- ClusterRole rules
+    rules: []
+    #   - apiGroups: [""]
+    #     resources: ["nodes"]
+    #     verbs: ["get", "list", "watch"]
+
+# -- Deployment configuration
+deployment:
+  # -- Deployment labels
+  labels: {}
+  # -- Deployment annotations
+  annotations: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Override the name of the chart
+nameOverride: ""
+
+# -- Override the full name of the release
+fullnameOverride: ""
+
+# -- Common labels added to all resources
+commonLabels: {}
+#   team: claw-bots
+
+# -- Common annotations added to all resources
+commonAnnotations: {}

--- a/charts/claw/values.yaml
+++ b/charts/claw/values.yaml
@@ -1,29 +1,47 @@
 # Claw Chart - Default Values
+#
+# This chart deploys a single-replica claw bot with a hardened security profile,
+# optional persistent storage, and configurable Kubernetes RBAC.
+#
+# Quick start (minimal configuration):
+#   helm install my-claw . --set image.repository=my-registry/claw-bot --set persistence.enabled=true
+#
+# For production, consider enabling:
+#   - persistence.enabled (PVC for bot workspace)
+#   - serviceAccount.create (dedicated service account)
+#   - rbac.create (with role and/or clusterRole rules)
+#   - resources (CPU/memory requests and limits)
 
-# -- Number of replicas for the deployment
+# -- Number of replicas. The chart uses Recreate strategy, so scaling beyond 1
+# is only safe with shared-nothing workloads or external coordination.
 replicaCount: 1
 
-# -- Image configuration
+# -- Container image configuration. repository is required.
 image:
-  # -- Container image repository
+  # -- Container image repository (e.g. my-registry/claw-bot)
   repository: ""
-  # -- Container image tag (defaults to Chart.appVersion if not set)
+  # -- Container image tag. Defaults to Chart.appVersion when empty.
+  # Override this to pin a specific version (recommended for production).
   tag: ""
-  # -- Image pull policy
+  # -- Image pull policy: Always, IfNotPresent, or Never
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets for private container registries.
+# Each entry must have a `name` referencing a pre-existing Secret in the namespace.
 imagePullSecrets: []
 #   - name: my-registry-secret
 
-# -- Override the container command
+# -- Override the container entrypoint. If empty, the image's default ENTRYPOINT is used.
 command: []
 #   - /bin/sh
 #   - -c
 
-# -- Override the container arguments
+# -- Arguments passed to the container command. If empty, the image's default CMD is used.
 args: []
+#   - "claw-bot --config /workspace/config.yaml"
 
-# -- Resource requests and limits
+# -- Resource requests and limits for the claw bot container.
+# Setting requests ensures QoS and scheduling; limits prevent resource starvation.
 resources: {}
 #   requests:
 #     cpu: 100m
@@ -32,115 +50,184 @@ resources: {}
 #     cpu: 500m
 #     memory: 512Mi
 
-# -- Volume mounts for the container
+# -- Additional volume mounts attached to the claw bot container.
+# The workspace PVC (if enabled) is always mounted at persistence.mountPath.
+# Use this for ConfigMaps, Secrets, or other volumes your bot needs.
 volumeMounts: []
-#   - name: extra-volume
-#     mountPath: /extra
+#   - name: bot-config
+#     mountPath: /etc/claw
 #     readOnly: true
 
-# -- Volumes for the pod
+# -- Additional volumes attached to the pod.
+# The workspace PVC volume is always present (referencing either a chart-created
+# PVC or an existing claim).
 volumes: []
-#   - name: extra-volume
+#   - name: bot-config
 #     configMap:
-#       name: my-config
+#       name: claw-config
+#   - name: bot-secrets
+#     secret:
+#       secretName: claw-secrets
 
-# -- Environment variables
+# -- Environment variables injected into the claw bot container.
+# Supports both literal values and valueFrom references (ConfigMap, Secret, FieldRef, etc.).
 env: []
-#   - name: MY_VAR
-#     value: "my-value"
-#   - name: SECRET_VAR
+#   - name: CLAW_ENV
+#     value: "production"
+#   - name: CLAW_TOKEN
 #     valueFrom:
 #       secretKeyRef:
-#         name: my-secret
-#         key: secret-key
+#         name: claw-secrets
+#         key: token
 
-# -- Pod-level security context
+# -- Pod-level security context applied to all containers in the pod.
+# Override to set fsGroup, runAsUser, sysctls, etc.
 podSecurityContext:
+  # -- Require the container to run as a non-root user (UID != 0)
   runAsNonRoot: true
 
-# -- Container-level security context
+# -- Container-level security context. By default the chart enforces a
+# locked-down profile: read-only root filesystem, no privilege escalation,
+# and all Linux capabilities dropped. Override individual fields as needed;
+# the defaults are safe for most workloads.
 securityContext:
+  # -- Mount the container's root filesystem as read-only (prevents writes outside volumes)
   readOnlyRootFilesystem: true
+  # -- Prevent the container from gaining more privileges than its parent process
   allowPrivilegeEscalation: false
+  # -- Linux capabilities assigned to the container
   capabilities:
+    # -- Drop all capabilities. Add back only what the bot requires (e.g. NET_BIND_SERVICE)
     drop:
       - ALL
 
-# -- Persistence configuration
+# -- Persistence configuration for the bot's workspace.
+# The workspace volume stores bot state, cached data, logs, etc.
 persistence:
-  # -- Enable PVC creation
+  # -- Enable creation of a PersistentVolumeClaim for the workspace.
+  # Set to true to have the chart manage the PVC lifecycle.
   enabled: false
-  # -- Use an existing PVC (mutually exclusive with enabled)
+  # -- Name of an existing PVC to use instead of creating one.
+  # When set, the chart skips PVC creation and uses this claim.
+  # Mutually exclusive with enabled (takes precedence).
   existingClaim: ""
-  # -- PVC size
+  # -- Requested storage size for the chart-managed PVC (ignored when existingClaim is set)
   size: 10Gi
-  # -- PVC access modes
+  # -- Access modes for the chart-managed PVC. ReadWriteOnce (RWO) is sufficient for
+  # a single-replica deployment and is the most widely supported mode.
+  # Options: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod
   accessModes:
     - ReadWriteOnce
-  # -- PVC storage class name
+  # -- Storage class name for the PVC. Leave empty to use the cluster's default StorageClass.
   storageClassName: ""
-  # -- Mount path for the PVC
+  # -- Filesystem path where the workspace PVC is mounted inside the container
   mountPath: /workspace
 
-# -- Service account configuration
+# -- Service account configuration.
+# A dedicated service account is required when enabling RBAC (rbac.create).
 serviceAccount:
-  # -- Create a service account
+  # -- Create a ServiceAccount for the claw bot deployment.
+  # Set to true to enable; required if rbac.create is true.
   create: false
-  # -- Service account name (generated if not set and create is true)
+  # -- Name of the ServiceAccount. If empty and create is true, the chart
+  # generates a name from the release (release-name-claw).
+  # If create is false, set this to the name of an existing ServiceAccount to use.
   name: ""
-  # -- Service account annotations
+  # -- Annotations added to the ServiceAccount (e.g. IAM role ARN for EKS).
+  # Merged with commonAnnotations.
   annotations: {}
-  # -- Service account labels
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/claw-role
+  # -- Labels added to the ServiceAccount. Merged with commonLabels.
   labels: {}
 
-# -- RBAC configuration
+# -- RBAC configuration for the claw bot.
+# Creates Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources
+# based on the rules you define. The ServiceAccount (serviceAccount.create)
+# must be enabled for RBAC to be useful.
 rbac:
-  # -- Create RBAC resources
+  # -- Enable creation of RBAC resources. When true, role and/or clusterRole
+  # rules are rendered into Kubernetes RBAC resources.
   create: false
-  # -- Namespaced role configuration
+  # -- Namespaced Role and RoleBinding.
+  # Grants permissions scoped to the release namespace.
   role:
-    # -- Role rules
+    # -- Role rules. Each entry is a standard Kubernetes RBAC rule with
+    # apiGroups, resources, and verbs. Leave empty to skip Role creation.
     rules: []
     #   - apiGroups: [""]
-    #     resources: ["pods"]
+    #     resources: ["pods", "configmaps"]
     #     verbs: ["get", "list", "watch"]
-  # -- ClusterRole configuration
+    #   - apiGroups: ["batch"]
+    #     resources: ["jobs"]
+    #     verbs: ["create", "get", "list", "delete"]
+  # -- Cluster-scoped ClusterRole and ClusterRoleBinding.
+  # Grants permissions across all namespaces.
   clusterRole:
-    # -- ClusterRole rules
+    # -- ClusterRole rules. Same format as role.rules. Leave empty to skip
+    # ClusterRole creation.
     rules: []
     #   - apiGroups: [""]
-    #     resources: ["nodes"]
+    #     resources: ["nodes", "persistentvolumes"]
     #     verbs: ["get", "list", "watch"]
 
-# -- Deployment configuration
+# -- Deployment configuration for labels and annotations on the Deployment resource
+# and its pod template. These are merged with commonLabels/commonAnnotations.
 deployment:
-  # -- Deployment labels
+  # -- Labels added to the Deployment resource metadata
   labels: {}
-  # -- Deployment annotations
+  #   app-part-of: claw-platform
+  # -- Annotations added to the Deployment resource metadata
   annotations: {}
-  # -- Pod labels
+  #   deploy-tool: helm
+  # -- Labels added to the pod template (in addition to selector labels and commonLabels)
   podLabels: {}
-  # -- Pod annotations
+  #   version: "2.0"
+  # -- Annotations added to the pod template (in addition to commonAnnotations)
   podAnnotations: {}
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "9090"
 
-# -- Node selector for pod scheduling
+# -- Node selector constrains the pod to nodes matching these labels.
 nodeSelector: {}
+#   disktype: ssd
+#   kubernetes.io/arch: amd64
 
-# -- Tolerations for pod scheduling
+# -- Tolerations allow the pod to schedule on nodes with matching taints.
 tolerations: []
+#   - key: dedicated
+#     operator: Equal
+#     value: claw
+#     effect: NoSchedule
 
-# -- Affinity rules for pod scheduling
+# -- Affinity rules control pod placement (node affinity, pod anti-affinity, etc.).
 affinity: {}
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#         - matchExpressions:
+#             - key: topology.kubernetes.io/zone
+#               operator: In
+#               values:
+#                 - us-east-1a
 
-# -- Override the name of the chart
+# -- Override the name of the chart (used in resource name generation).
+# Defaults to .Chart.Name ("claw").
 nameOverride: ""
 
-# -- Override the full name of the release
+# -- Override the full resource name entirely. When set, this replaces
+# the release-name-chart pattern used for all generated resources.
 fullnameOverride: ""
 
-# -- Common labels added to all resources
+# -- Labels added to ALL resources created by this chart.
+# Merged with resource-specific labels (e.g. serviceAccount.labels, deployment.labels).
 commonLabels: {}
 #   team: claw-bots
+#   environment: production
 
-# -- Common annotations added to all resources
+# -- Annotations added to ALL resources created by this chart.
+# Merged with resource-specific annotations. For the ServiceAccount and Deployment,
+# both the resource-specific and common annotation sources are merged into a single
+# annotations block.
 commonAnnotations: {}
+#   managed-by: platform-team
+#   owner: sre


### PR DESCRIPTION
## Summary

Adds a standalone Helm chart for deploying claw bots with:
- **Hardened security**: read-only root FS, drop all capabilities, runAsNonRoot
- **Recreate deployment strategy** (single replica)
- **Configurable PVC** (chart-managed or pre-existing, default 10Gi at /workspace)
- **RBAC support**: namespaced Role/RoleBinding and cluster ClusterRole/ClusterRoleBinding with configurable rules via values
- **ServiceAccount** with configurable labels and annotations
- **Labels and annotations** configurable on all significant resources (deployment, SA, pods), with common labels propagated to all resources
- **Comprehensive values.yaml** with extensive documentation

## Files

```
charts/claw/
  Chart.yaml
  .helmignore
  values.yaml
  values.schema.json
  templates/
    _helpers.tpl
    deployment.yaml
    serviceaccount.yaml
    pvc.yaml
    role.yaml
    rolebinding.yaml
    clusterrole.yaml
    clusterrolebinding.yaml
  tests/
    deployment_test.yaml
    serviceaccount_test.yaml
    pvc_test.yaml
    rbac_test.yaml (+ 5 rbac test files)
```

## Verification

```
$ make all CHARTS=charts/claw
helm lint:       0 failures
yamllint:        passed
helm template:   renders successfully
helm unittest:   9 suites, 41 tests, all passed
```