### PR TITLE
feat: add claw-jobs chart for Bun JS CronJobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/charts/claw-jobs/Chart.yaml
+++ b/charts/claw-jobs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: claw-jobs
+description: A Helm chart for deploying Bun JS programs as Kubernetes CronJobs
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/claw-jobs/templates/_helpers.tpl
+++ b/charts/claw-jobs/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "claw-jobs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "claw-jobs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "claw-jobs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "claw-jobs.labels" -}}
+helm.sh/chart: {{ include "claw-jobs.chart" . }}
+{{ include "claw-jobs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "claw-jobs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "claw-jobs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "claw-jobs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "claw-jobs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "claw-jobs.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}

--- a/charts/claw-jobs/templates/configmap.yaml
+++ b/charts/claw-jobs/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- range .Values.jobs }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "claw-jobs.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "claw-jobs.labels" $ | nindent 4 }}
+    {{- with $.Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with $.Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{ .name }}.bun.js: |
+{{ .script | indent 4 }}
+{{- end }}

--- a/charts/claw-jobs/templates/cronjob.yaml
+++ b/charts/claw-jobs/templates/cronjob.yaml
@@ -1,0 +1,87 @@
+{{- range .Values.jobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "claw-jobs.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "claw-jobs.labels" $ | nindent 4 }}
+    {{- with $.Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with $.Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  schedule: {{ .schedule | quote }}
+  {{- with .timeZone | default $.Values.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  {{- with .startingDeadlineSeconds | default $.Values.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
+  concurrencyPolicy: {{ .concurrencyPolicy | default $.Values.concurrencyPolicy }}
+  suspend: {{ if hasKey . "suspend" }}{{ .suspend }}{{ else }}{{ $.Values.suspend }}{{ end }}
+  successfulJobsHistoryLimit: {{ .successfulJobsHistoryLimit | default $.Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .failedJobsHistoryLimit | default $.Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .backoffLimit | default $.Values.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "claw-jobs.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: {{ .name }}
+          {{- with $.Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ include "claw-jobs.serviceAccountName" $ }}
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          restartPolicy: {{ .restartPolicy | default $.Values.restartPolicy }}
+          containers:
+            - name: {{ .name }}
+              image: {{ include "claw-jobs.image" $ }}
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              command: ["bun", "run", "/scripts/{{ .name }}.bun.js"]
+              env:
+                {{- range $key, $val := $.Values.env }}
+                - name: {{ $key | quote }}
+                  value: {{ $val | quote }}
+                {{- end }}
+                {{- range $key, $val := .env }}
+                - name: {{ $key | quote }}
+                  value: {{ $val | quote }}
+                {{- end }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              resources:
+                {{- toYaml (.resources | default $.Values.resources) | nindent 16 }}
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: script
+              configMap:
+                name: {{ include "claw-jobs.fullname" $ }}-{{ .name }}
+          {{- with .nodeSelector | default $.Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .tolerations | default $.Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .affinity | default $.Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/claw-jobs/templates/serviceaccount.yaml
+++ b/charts/claw-jobs/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "claw-jobs.serviceAccountName" . }}
+  labels:
+    {{- include "claw-jobs.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/claw-jobs/tests/configmap_test.yaml
+++ b/charts/claw-jobs/tests/configmap_test.yaml
@@ -1,0 +1,65 @@
+suite: test configmap template
+templates:
+  - configmap.yaml
+release:
+  name: my-release
+  namespace: test-ns
+tests:
+  - it: renders a ConfigMap per job
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello from bun");
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-release-claw-jobs-test-job
+      - equal:
+          path: data["test-job.bun.js"]
+          value: "console.log(\"hello from bun\");\n"
+
+  - it: renders multiple ConfigMaps
+    set:
+      jobs:
+        - name: job-a
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("a");
+        - name: job-b
+          schedule: "0 * * * *"
+          script: |
+            console.log("b");
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: my-release-claw-jobs-job-a
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: my-release-claw-jobs-job-b
+
+  - it: renders commonLabels and commonAnnotations
+    set:
+      commonLabels:
+        team: platform
+      commonAnnotations:
+        description: test annotation
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.annotations.description
+          value: test annotation

--- a/charts/claw-jobs/tests/cronjob_test.yaml
+++ b/charts/claw-jobs/tests/cronjob_test.yaml
@@ -1,0 +1,276 @@
+suite: test cronjob template
+templates:
+  - cronjob.yaml
+release:
+  name: my-release
+  namespace: test-ns
+tests:
+  - it: renders a CronJob per job
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["bun", "run", "/scripts/test-job.bun.js"]
+
+  - it: renders global env vars
+    set:
+      env:
+        LOG_LEVEL: info
+        NODE_ENV: production
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[0]
+          value:
+            name: LOG_LEVEL
+            value: info
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[1]
+          value:
+            name: NODE_ENV
+            value: production
+
+  - it: merges per-job env on top of global env (per-job wins)
+    set:
+      env:
+        SHARED: global-value
+        UNIQUE: global-only
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          env:
+            SHARED: per-job-value
+            PER_JOB: job-only
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: SHARED
+            value: per-job-value
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: UNIQUE
+            value: global-only
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PER_JOB
+            value: job-only
+
+  - it: defaults timeZone to Europe/Copenhagen
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - equal:
+          path: spec.timeZone
+          value: Europe/Copenhagen
+
+  - it: respects per-job timeZone override
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          timeZone: America/New_York
+    asserts:
+      - equal:
+          path: spec.timeZone
+          value: America/New_York
+
+  - it: respects per-job backoffLimit override
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          backoffLimit: 10
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 10
+
+  - it: supports suspend
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          suspend: true
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: true
+
+  - it: renders security context defaults
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: renders resources
+    set:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+
+  - it: renders startingDeadlineSeconds
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          startingDeadlineSeconds: 120
+    asserts:
+      - equal:
+          path: spec.startingDeadlineSeconds
+          value: 120
+
+  - it: renders concurrencyPolicy
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          concurrencyPolicy: Allow
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Allow
+
+  - it: renders multiple jobs
+    set:
+      jobs:
+        - name: job-a
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("a");
+        - name: job-b
+          schedule: "0 * * * *"
+          script: |
+            console.log("b");
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: CronJob
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: my-release-claw-jobs-job-a
+      - documentIndex: 1
+        isKind:
+          of: CronJob
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: my-release-claw-jobs-job-b
+
+  - it: renders nodeSelector
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          nodeSelector:
+            disktype: ssd
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: renders tolerations
+    set:
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+          tolerations:
+            - key: "key1"
+              operator: "Equal"
+              value: "value1"
+              effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.tolerations[0].key
+          value: key1
+
+  - it: renders commonLabels
+    set:
+      commonLabels:
+        team: platform
+        env: prod
+      jobs:
+        - name: test-job
+          schedule: "*/5 * * * *"
+          script: |
+            console.log("hello");
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.env
+          value: prod

--- a/charts/claw-jobs/tests/serviceaccount_test.yaml
+++ b/charts/claw-jobs/tests/serviceaccount_test.yaml
@@ -1,0 +1,37 @@
+suite: test serviceaccount template
+templates:
+  - serviceaccount.yaml
+release:
+  name: my-release
+  namespace: test-ns
+tests:
+  - it: renders ServiceAccount when serviceAccount.create is true
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: my-release-claw-jobs
+
+  - it: does not render when serviceAccount.create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses custom service account name
+    set:
+      serviceAccount:
+        create: true
+        name: my-custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-sa

--- a/charts/claw-jobs/values.yaml
+++ b/charts/claw-jobs/values.yaml
@@ -1,0 +1,49 @@
+replicaCount: 1
+
+image:
+  repository: oven/bun
+  tag: "1.3.14"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+env: {}
+
+backoffLimit: 3
+restartPolicy: Never
+concurrencyPolicy: Forbid
+successfulJobsHistoryLimit: 3
+failedJobsHistoryLimit: 3
+startingDeadlineSeconds:
+timeZone: "Europe/Copenhagen"
+suspend: false
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+commonLabels: {}
+commonAnnotations: {}
+
+jobs: []


### PR DESCRIPTION
## Summary

- New `charts/claw-jobs/` Helm chart for deploying Bun JS programs as Kubernetes CronJobs
- Each job entry creates a ConfigMap (script mount) + CronJob (bun run /scripts/<name>.bun.js)
- Global env vars merged with per-job env vars (per-job wins)
- All CronJob spec fields configurable globally with per-job overrides
- Default timeZone set to Europe/Copenhagen
- Hardened security defaults (non-root, readOnlyRootFilesystem, drop all capabilities)
- 21 unit tests across 3 test suites

## Test Plan

- [x] `make all` — lint, yamllint, helm template, helm unittest — all pass (113 tests total)
- [x] No regressions in existing charts (claw, general-service, manifests)